### PR TITLE
Add more frame unwrapping support 

### DIFF
--- a/src/choppera/nexus.py
+++ b/src/choppera/nexus.py
@@ -521,6 +521,8 @@ def unwrap_histogram(
         point = int(argmin(diff)) + 1
         axis = next(iter(i for i, n in enumerate(values.dims) if n == dim))
         values.values = roll(values.values, -point, axis=axis)
+        if values.variances is not None:
+            values.variances = roll(values.variances, -point, axis=axis)
         leading = roll(leading, -point)
         trailing = roll(trailing, -point)
     if any(leading[1:] != trailing[:-1]):


### PR DESCRIPTION
Normalizing data for, e.g., BIFROST, requires unwapping the incident beam monitor which may be histogram data.
A new method is added that handles unwrapping bin edges, including the possibility to split a bin if it crosses the pivot point.